### PR TITLE
X11: Fix segfault when using NVidia EGL

### DIFF
--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -800,8 +800,6 @@ void _glfwPlatformTerminate(void)
         _glfw.x11.im = NULL;
     }
 
-    _glfwTerminateEGL();
-
     if (_glfw.x11.display)
     {
         XCloseDisplay(_glfw.x11.display);
@@ -810,6 +808,7 @@ void _glfwPlatformTerminate(void)
 
     // NOTE: This needs to be done after XCloseDisplay, as libGL registers
     //       cleanup callbacks that get called by it
+    _glfwTerminateEGL();
     _glfwTerminateGLX();
 
     _glfwTerminateJoysticksLinux();


### PR DESCRIPTION
Fix by @elmindreda: https://github.com/glfw/glfw/commit/9e6c0c747be838d1f3dc38c2924a47a42416c081

This should solve https://github.com/wjakob/nanogui/issues/342 . Tested on:

- ArchLinux, Ubuntu (NVIDIA GPU). Solves the crash in `shutdown`.
- macOS (unaffected)
- Windows (unaffected)