### PR TITLE
fix(wayland): cross compile conflict on aarch64 platform

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -26,7 +26,6 @@
 //
 //========================================================================
 
-#include "GLFW/glfw3.h"
 #include "internal.h"
 
 #include <assert.h>


### PR DESCRIPTION
fix compile error when I cross compile with aarch64 platform. I checked upstream glfw repo, I found there is no need to add ``#include "GLFW/glfw3.h"`` here, so I delete this line code.