### PR TITLE
feat(wayland): use `axis_value120` instead of `axis` events if supported

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -223,7 +223,7 @@ static void registryHandleGlobal(void* userData,
         {
             _glfw.wl.seat =
                 wl_registry_bind(registry, name, &wl_seat_interface,
-                                 _glfw_min(4, version));
+                                 _glfw_min(8, version));
             _glfwAddSeatListenerWayland(_glfw.wl.seat);
 
             if (wl_seat_get_version(_glfw.wl.seat) >=

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1862,11 +1862,55 @@ static void pointerHandleAxis(void* userData,
     if (!window)
         return;
 
-    // NOTE: 10 units of motion per mouse wheel step seems to be a common ratio
+    if (wl_pointer_get_version(pointer) >= WL_POINTER_AXIS_VALUE120_SINCE_VERSION)
+        // Ignore this event, as we will get a more precise axis_value120 event
+        return;
+
+    // NOTE: 15 units of motion per mouse wheel step seems to be a common ratio to wheel detents
     if (axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL)
-        _glfwInputScroll(window, -wl_fixed_to_double(value) / 10.0, 0.0);
+        _glfwInputScroll(window, -wl_fixed_to_double(value) / 15.0, 0.0);
     else if (axis == WL_POINTER_AXIS_VERTICAL_SCROLL)
-        _glfwInputScroll(window, 0.0, -wl_fixed_to_double(value) / 10.0);
+        _glfwInputScroll(window, 0.0, -wl_fixed_to_double(value) / 15.0);
+}
+
+static void pointerHandleFrame(void* userData,
+                               struct wl_pointer* pointer)
+{
+}
+
+static void pointerHandleAxisSource(void* userData,
+                                    struct wl_pointer* pointer,
+                                    uint32_t axisSource)
+{
+}
+
+static void pointerHandleAxisStop(void* userData,
+                                  struct wl_pointer* pointer,
+                                  uint32_t time,
+                                  uint32_t axis)
+{
+}
+
+static void pointerHandleAxisDiscrete(void* userData,
+                                      struct wl_pointer* pointer,
+                                      uint32_t axis,
+                                      int32_t discrete)
+{
+}
+
+static void pointerHandleAxisValue120(void* userData,
+                                     struct wl_pointer* pointer,
+                                     uint32_t axis,
+                                     int32_t value120)
+{
+    _GLFWwindow* window = _glfw.wl.pointerFocus;
+    if (!window)
+        return;
+
+    if (axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL)
+        _glfwInputScroll(window, -value120 / 120.0f, 0.0);
+    else if (axis == WL_POINTER_AXIS_VERTICAL_SCROLL)
+        _glfwInputScroll(window, 0.0, -value120 / 120.0f);
 }
 
 static const struct wl_pointer_listener pointerListener =
@@ -1876,6 +1920,11 @@ static const struct wl_pointer_listener pointerListener =
     pointerHandleMotion,
     pointerHandleButton,
     pointerHandleAxis,
+    pointerHandleFrame,
+    pointerHandleAxisSource,
+    pointerHandleAxisStop,
+    pointerHandleAxisDiscrete,
+    pointerHandleAxisValue120,
 };
 
 static void keyboardHandleKeymap(void* userData,


### PR DESCRIPTION
See https://github.com/Tom94/tev/issues/365#issuecomment-3433367828 for the issue that this fixes.

`axis_value120` events are precise while, unlike `axis` events, having a clear correspondence to discrete scroll events (detents in the mouse wheel). This makes for more precise scroll handling overall.

This commit also adjusts the default scale factor of `axis` events to 15 (from 10) to make it more in line with typical detent scale.