### PR TITLE
Gamma 2.2 by default

### DIFF
--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1086,7 +1086,7 @@ uint32_t _glfwGetWindowPrimariesCocoa(_GLFWwindow* window)
 
 uint32_t _glfwGetWindowTransferCocoa(_GLFWwindow* window)
 {
-    return 10; // EXT sRGB
+    return 2; // Gamma 2.2
 }
 
 void _glfwGetWindowSizeCocoa(_GLFWwindow* window, int* width, int* height)

--- a/src/null_window.c
+++ b/src/null_window.c
@@ -269,7 +269,7 @@ uint32_t _glfwGetWindowPrimariesNull(_GLFWwindow* window)
 
 uint32_t _glfwGetWindowTransferNull(_GLFWwindow* window)
 {
-    return 10; // EXT sRGB
+    return 2; // Gamma 2.2
 }
 
 void _glfwGetWindowSizeNull(_GLFWwindow* window, int* width, int* height)

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1759,15 +1759,12 @@ float _glfwGetWindowMinLuminanceWin32(_GLFWwindow* window) {
 }
 
 GLFWbool _glfwGetWindowAdvancedColorEnabledWin32(_GLFWwindow* window) {
-    if (window->bitsPerSample != 16) {
-        // If we don't have a fp16 frame buffer, Windows does not expect scRGB
-        // with proper SDR white level scaling, it instead expects standard
-        // sRGB whose reference white level should be 80 nits. (Even though the
-        // screen's reference white level -- obtained by the bottom code --
-        // might be different. In that case Windows does the remapping for us.)
-        return GLFW_FALSE;
-    }
-
+    // Note: we cannot early return based on whether we have a 16 bit buffer.
+    // Some drivers won't give us a 16 bit buffer, even if advanced color is enabled
+    // (e.g. in pure wide-color, non-HDR situations, or when the driver is limited).
+    // In such cases, advanced color determines whether Windows treats out data as sRGB piecewise
+    // or whether it simply forwards it to the monitor, in which case we should produce gamma 2.2
+    // instead to match what most monitors do.
     UINT32 numPaths, numModes;
     LONG result;
 
@@ -1838,7 +1835,7 @@ GLFWbool _glfwGetWindowAdvancedColorEnabledWin32(_GLFWwindow* window) {
         _glfw_free(paths);
         _glfw_free(modes);
 
-        return advancedColorInfo.advancedColorEnabled != 0;
+        return advancedColorInfo.advancedColorEnabled != 0 || advancedColorInfo.wideColorEnforced != 0;
     }
 
     _glfw_free(paths);
@@ -1850,7 +1847,7 @@ GLFWbool _glfwGetWindowAdvancedColorEnabledWin32(_GLFWwindow* window) {
 float _glfwGetWindowMaxLuminanceWin32(_GLFWwindow* window) {
     // If advanced color is not enabled, return standard sRGB max luminance (not HDR).
     // Otherwise return 0.0 to indicate no known limit.
-    return _glfwGetWindowAdvancedColorEnabledWin32(window) ? 0.0f : 80.0f;
+    return window->bitsPerSample >= 16 && _glfwGetWindowAdvancedColorEnabledWin32(window) ? 0.0f : 80.0f;
 }
 
 uint32_t _glfwGetWindowPrimariesWin32(_GLFWwindow* window)
@@ -1861,8 +1858,9 @@ uint32_t _glfwGetWindowPrimariesWin32(_GLFWwindow* window)
 uint32_t _glfwGetWindowTransferWin32(_GLFWwindow* window)
 {
     // If we managed to get a fp16 frame buffer on Windows, we need to output scRGB
-    // i.e. linear colors w/ sRGB primaries.
-    return window->bitsPerSample == 16 ? 5 : 10; // 5 == linear, 10 == EXT sRGB
+    // i.e. linear colors w/ sRGB primaries. Notably, Windows recently 
+    // 5 == linear, 10 == EXT sRGB, 2 == gamma 2.2
+    return window->bitsPerSample >= 16 ? 5 : (_glfwGetWindowAdvancedColorEnabledWin32(window) ? 10 : 2);
 }
 
 void _glfwGetWindowSizeWin32(_GLFWwindow* window, int* width, int* height)

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1219,13 +1219,16 @@ static GLFWbool supportsColorManagement(_GLFWwindow* window)
         return GLFW_FALSE;
 
     if (!_glfw.wl.colorManagerSupport.primaries[WP_COLOR_MANAGER_V1_PRIMARIES_SRGB] &&
+        !_glfw.wl.colorManagerSupport.primaries[WP_COLOR_MANAGER_V1_PRIMARIES_DISPLAY_P3] &&
+        !_glfw.wl.colorManagerSupport.primaries[WP_COLOR_MANAGER_V1_PRIMARIES_DCI_P3] &&
+        !_glfw.wl.colorManagerSupport.primaries[WP_COLOR_MANAGER_V1_PRIMARIES_ADOBE_RGB] &&
         !_glfw.wl.colorManagerSupport.primaries[WP_COLOR_MANAGER_V1_PRIMARIES_BT2020])
         return GLFW_FALSE;
 
     if (!_glfw.wl.colorManagerSupport.tfs[WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_SRGB] &&
         !_glfw.wl.colorManagerSupport.tfs[WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_GAMMA22] &&
         !_glfw.wl.colorManagerSupport.tfs[WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_ST2084_PQ] &&
-        !_glfw.wl.colorManagerSupport.tfs[WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_EXT_SRGB])
+        !_glfw.wl.colorManagerSupport.tfs[WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_EXT_LINEAR])
         return GLFW_FALSE;
 
     return GLFW_TRUE;
@@ -2704,15 +2707,22 @@ uint32_t _glfwGetWindowTransferWayland(_GLFWwindow* window)
     if (!supportsColorManagement(window))
         return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_GAMMA22;
 
+    // If we've got 16 bits per sample, that means we have a floating point buffer that supports
+    // negative values for arbitrarily wide color spaces. Furthermore, floating point buffers
+    // are inherently perceptually ~linear, so we should prefer linear transfer above other options.
+    if (window->bitsPerSample >= 16) {
+        if (_glfw.wl.colorManagerSupport.tfs[WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_EXT_LINEAR])
+            return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_EXT_LINEAR;
+    }
+
+    // Else, (e.g. with 10 or 12 bits buffers), prefer PQ since that'll give us a high dynamic range
     if (_glfw.wl.colorManagerSupport.tfs[WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_ST2084_PQ]
         && (window->wl.maxLuminance == 0.0f || window->wl.maxLuminance > 80.0f))
         return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_ST2084_PQ;
 
-    if (_glfw.wl.colorManagerSupport.tfs[WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_EXT_SRGB])
-        return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_EXT_SRGB;
-    if (_glfw.wl.colorManagerSupport.tfs[WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_SRGB])
-        return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_SRGB;
-    return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_GAMMA22;
+    if (_glfw.wl.colorManagerSupport.tfs[WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_GAMMA22])
+        return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_GAMMA22;
+    return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_SRGB; // Fall back to ambiguous sRGB only as a last resort
 }
 
 uint32_t _glfwGetWindowPrimariesWayland(_GLFWwindow* window)
@@ -2722,6 +2732,15 @@ uint32_t _glfwGetWindowPrimariesWayland(_GLFWwindow* window)
 
     if (_glfw.wl.colorManagerSupport.primaries[WP_COLOR_MANAGER_V1_PRIMARIES_BT2020])
         return WP_COLOR_MANAGER_V1_PRIMARIES_BT2020;
+
+    if (_glfw.wl.colorManagerSupport.primaries[WP_COLOR_MANAGER_V1_PRIMARIES_ADOBE_RGB])
+        return WP_COLOR_MANAGER_V1_PRIMARIES_ADOBE_RGB;
+
+    if (_glfw.wl.colorManagerSupport.primaries[WP_COLOR_MANAGER_V1_PRIMARIES_DCI_P3])
+        return WP_COLOR_MANAGER_V1_PRIMARIES_DCI_P3;
+
+    if (_glfw.wl.colorManagerSupport.primaries[WP_COLOR_MANAGER_V1_PRIMARIES_DISPLAY_P3])
+        return WP_COLOR_MANAGER_V1_PRIMARIES_DISPLAY_P3;
 
     return WP_COLOR_MANAGER_V1_PRIMARIES_SRGB;
 }

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2212,7 +2212,7 @@ uint32_t _glfwGetWindowPrimariesX11(_GLFWwindow* window)
 
 uint32_t _glfwGetWindowTransferX11(_GLFWwindow* window)
 {
-    return 10; // EXT sRGB
+    return 2; // Gamma 2.2
 }
 
 void _glfwGetWindowSizeX11(_GLFWwindow* window, int* width, int* height)


### PR DESCRIPTION
I recently got a calibrated monitor that I could run trustworthy gamma tests on -- turns out the second issue from https://github.com/wjakob/glfw/pull/11 runs deeper than expected: pretty much all monitors and/or environments expect gamma 2.2 encoded values when the color space is set to sRGB.

This includes unexpected situations like fp16 EDR macOS using `kCGColorSpaceExtendedSRGB`. The only situations in which an 8 or 10-bit SRGB buffer is expected to actually use the p/w sRGB transfer function seems to be SDR rendering on an HDR-enabled Windows desktop.

This PR fixes the GLFW side. nanogui will then work correctly on Windows and Linux, because of `colorpass.cpp`. However, nanogui forwards macOS buffers to the OS unchanged, so the full fix unfortunately requires either
- all nanogui users changing to gamma 2.2 rendering + [this change](https://github.com/Tom94/nanogui-1/commit/6ac15cb533ada16ff374f4d31854b9a75012bb0a) or
- running a color pass on macOS that'll transform sRGB -> gamma22 on demand.